### PR TITLE
Fix link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ data: {
 }
 ```
 
-More info: http://emberigniter.com/saving-relationships-hasmany-json-api/
+More info: http://emberigniter.com/saving-models-relationships-json-api/
 
 ## Installation
 


### PR DESCRIPTION
I noticed that the link to you blog is broken.
I used your addon, it was exactly what I needed.

Thanks
