### PR TITLE
null check 'data' object to correctly handle data: null objects

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -7,7 +7,7 @@ export default Ember.Mixin.create({
     const relKind = rel.kind;
     const relKey = rel.key;
 
-    if (this.get(`attrs.${relKey}.serialize`) === true) {
+    if (data && this.get(`attrs.${relKey}.serialize`) === true) {
 
       data.relationships = data.relationships || {};
       const key = this.keyForRelationship(relKey, relKind, 'serialize');
@@ -96,7 +96,7 @@ export default Ember.Mixin.create({
           json.type = Ember.String.singularize(json.type);
           this.updateRecord(json, store);
         });
-      } else {
+      } else if (relationshipData) {
         // belongsTo
         relationshipData.type = Ember.String.singularize(relationshipData.type);
         relationshipData = this.updateRecord(relationshipData, store);


### PR DESCRIPTION
Please merge in these null checks, which fix a bug for us when handling requests containing e.g.:

...
"relationships": {
    "example-model": {
        "data": null
    }
}
...

which is valid within JSON API
